### PR TITLE
泰拉瑞亚灾厄wiki浏览器页面截取

### DIFF
--- a/plugins.v4.json
+++ b/plugins.v4.json
@@ -298,7 +298,7 @@
       "name": "泰拉瑞亚灾厄模组Wiki查询",
       "version": "0.1.2",
       "description": "从wiki截取页面",
-      "author": "",
+      "author": "nanting",
       "homepage": "https://github.com/NanTingPer/napcat-terraria-wiki-plugin",
       "downloadUrl": "https://github.com/NanTingPer/napcat-terraria-wiki-plugin/releases/download/v0.1.2/napcat-plugin-terraria-wiki.zip",
       "tags": [


### PR DESCRIPTION
- 可以截取灾厄wiki的页面
- 会删除多余内容，如标题导航栏、物品推荐表格、底部空白区域(保留版权)
- 图片会保存在配置的目录下，下次获取时 从缓存获取