### PR TITLE
🔌 [meme娱乐插件] 更新至 v1.3.1

### DIFF
--- a/plugins.v4.json
+++ b/plugins.v4.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updateTime": "2026-02-08T08:23:02Z",
+  "updateTime": "2026-02-08T08:36:22Z",
   "plugins": [
     {
       "id": "napcat-plugin-builtin",
@@ -46,12 +46,12 @@
     },
     {
       "id": "napcat-plugin-play",
-      "name": "Play 娱乐",
-      "version": "1.3.0",
-      "description": "娱乐插件，meme表情包，点歌，AI绘画(免费)制作。",
+      "name": "meme娱乐插件",
+      "version": "1.3.1",
+      "description": "娱乐插件，meme表情包，点歌，哈基米制作。",
       "author": "冷曦",
       "homepage": "https://github.com/lengxi-root/napcat-plugin-play",
-      "downloadUrl": "https://github.com/lengxi-root/napcat-plugin-play/releases/download/latest/napcat-plugin-play.zip",
+      "downloadUrl": "https://github.com/lengxi-root/napcat-plugin-play/releases/download/v1.3.1/napcat-plugin-play.zip",
       "tags": [
         "娱乐",
         "AI"


### PR DESCRIPTION
## 🤖 自动更新插件索引

| 字段 | 值 |
|------|-----|
| **插件 ID** | `napcat-plugin-play` |
| **插件名称** | meme娱乐插件 |
| **版本** | v1.3.1 |
| **作者** | 冷曦 |
| **下载链接** | https://github.com/lengxi-root/napcat-plugin-play/releases/download/v1.3.1/napcat-plugin-play.zip |
| **主页** | https://github.com/lengxi-root/napcat-plugin-play |
| **最低版本** | 4.14.0 |

---

> 此 PR 由 CI 自动创建，来源: [lengxi-root/napcat-plugin-play](https://github.com/lengxi-root/napcat-plugin-play) Release v1.3.1