### PR TITLE
🔌 [主人列表插件] 更新至 v1.0.4

### DIFF
--- a/plugins.v4.json
+++ b/plugins.v4.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updateTime": "2026-02-11T09:20:26Z",
+  "updateTime": "2026-02-11T10:27:25Z",
   "plugins": [
     {
       "id": "napcat-plugin-builtin",
@@ -406,11 +406,11 @@
     {
       "id": "napcat-plugin-master",
       "name": "主人列表插件",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "NapCat 插件标准主人列表",
       "author": "瑜笙",
       "homepage": "https://github.com/ys7zTS/napcat-plugin-master",
-      "downloadUrl": "https://github.com/ys7zTS/napcat-plugin-master/releases/download/v1.0.3/napcat-plugin-master.zip",
+      "downloadUrl": "https://github.com/ys7zTS/napcat-plugin-master/releases/download/v1.0.4/napcat-plugin-master.zip",
       "tags": [
         "工具"
       ],


### PR DESCRIPTION
## 🤖 自动更新插件索引

| 字段 | 值 |
|------|-----|
| **插件 ID** | `napcat-plugin-master` |
| **插件名称** | 主人列表插件 |
| **版本** | v1.0.4 |
| **作者** | 瑜笙 |
| **下载链接** | https://github.com/ys7zTS/napcat-plugin-master/releases/download/v1.0.4/napcat-plugin-master.zip |
| **主页** | https://github.com/ys7zTS/napcat-plugin-master |
| **最低版本** | 4.14.0 |

---

> 此 PR 由 CI 自动创建，来源: [ys7zTS/napcat-plugin-master](https://github.com/ys7zTS/napcat-plugin-master) Release v1.0.4