### PR TITLE
🔌 [群名称插件] 更新至 v1.0.1

### DIFF
--- a/plugins.v4.json
+++ b/plugins.v4.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updateTime": "2026-02-12T07:55:35Z",
+  "updateTime": "2026-02-12T08:17:33Z",
   "plugins": [
     {
       "id": "napcat-plugin-builtin",
@@ -448,11 +448,11 @@
     {
       "id": "napcat-plugin-groupname",
       "name": "群名称插件",
-      "version": "V1.0.0",
+      "version": "1.0.1",
       "description": "NapCat 插件 - 群名称插件",
       "author": "lingran7031",
       "homepage": "https://github.com/lingran7031/napcat-plugin-groupname",
-      "downloadUrl": "https://github.com/lingran7031/napcat-plugin-groupname/releases/download/V1.0.0/napcat-plugin-groupname.zip",
+      "downloadUrl": "https://github.com/lingran7031/napcat-plugin-groupname/releases/download/v1.0.1/napcat-plugin-groupname.zip",
       "tags": [
         "工具"
       ],


### PR DESCRIPTION
## 🤖 自动更新插件索引

| 字段 | 值 |
|------|-----|
| **插件 ID** | `napcat-plugin-groupname` |
| **插件名称** | 群名称插件 |
| **版本** | v1.0.1 |
| **作者** | lingran7031 |
| **下载链接** | https://github.com/lingran7031/napcat-plugin-groupname/releases/download/v1.0.1/napcat-plugin-groupname.zip |
| **主页** | https://github.com/lingran7031/napcat-plugin-groupname |
| **最低版本** | 4.14.0 |

---

> 此 PR 由 CI 自动创建，来源: [lingran7031/napcat-plugin-groupname](https://github.com/lingran7031/napcat-plugin-groupname) Release v1.0.1