### PR TITLE
🔌 [GScore 适配器] 更新至 v1.0.1

### DIFF
--- a/plugins.v4.json
+++ b/plugins.v4.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updateTime": "2026-02-13T03:07:19Z",
+  "updateTime": "2026-02-13T03:41:52Z",
   "plugins": [
     {
       "id": "napcat-plugin-builtin",
@@ -497,6 +497,19 @@
       "tags": [
         "工具",
         "娱乐"
+      ],
+      "minVersion": "4.14.0"
+    },
+    {
+      "id": "napcat-plugin-gscore-adapter",
+      "name": "GScore 适配器",
+      "version": "1.0.1",
+      "description": "一个适用于NapCat的GScore适配器",
+      "author": "MortalCat",
+      "homepage": "https://github.com/xiowo/napcat-plugin-gscore-adapter",
+      "downloadUrl": "https://github.com/xiowo/napcat-plugin-gscore-adapter/releases/download/v1.0.1/napcat-plugin-gscore-adapter.zip",
+      "tags": [
+        "工具"
       ],
       "minVersion": "4.14.0"
     }


### PR DESCRIPTION
## 🤖 自动更新插件索引

| 字段 | 值 |
|------|-----|
| **插件 ID** | `napcat-plugin-gscore-adapter` |
| **插件名称** | GScore 适配器 |
| **版本** | v1.0.1 |
| **作者** | MortalCat |
| **下载链接** | https://github.com/xiowo/napcat-plugin-gscore-adapter/releases/download/v1.0.1/napcat-plugin-gscore-adapter.zip |
| **主页** | https://github.com/xiowo/napcat-plugin-gscore-adapter |
| **最低版本** | 4.14.0 |

---

> 此 PR 由 CI 自动创建，来源: [xiowo/napcat-plugin-gscore-adapter](https://github.com/xiowo/napcat-plugin-gscore-adapter) Release v1.0.1