### PR TITLE
🔌 [60s API] 更新至 v1.0.5

### DIFF
--- a/plugins.v4.json
+++ b/plugins.v4.json
@@ -584,11 +584,11 @@
     {
       "id": "napcat-plugin-60s-api",
       "name": "60s API",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "description": "60s API 聚合插件 - 聚合多种实用API，包括热点资讯、天气、榜单查询等功能",
       "author": "朝歌",
       "homepage": "https://github.com/chaoge/napcat-plugin-60s-api",
-      "downloadUrl": "https://github.com/Sakurakilove/napcat-plugin-60s-api/releases/download/v1.0.3/napcat-plugin-60s-api.zip",
+      "downloadUrl": "https://github.com/Sakurakilove/napcat-plugin-60s-api/releases/download/v1.0.5/napcat-plugin-60s-api.zip",
       "tags": [
         "工具",
         "资讯",


### PR DESCRIPTION
## 🤖 自动更新插件索引

| 字段 | 值 |
|------|-----|
| **插件 ID** | `napcat-plugin-60s-api` |
| **插件名称** | 60s API |
| **版本** | v1.0.5 |
| **作者** | 朝歌 |
| **下载链接** | https://github.com/Sakurakilove/napcat-plugin-60s-api/releases/download/v1.0.5/napcat-plugin-60s-api.zip |
| **主页** | https://github.com/chaoge/napcat-plugin-60s-api |
| **最低版本** | 4.14.0 |

---

> 此 PR 由 CI 自动创建，来源: [Sakurakilove/napcat-plugin-60s-api](https://github.com/chaoge/napcat-plugin-60s-api) Release v1.0.5