### PR TITLE
🔌 [今日老婆] 更新至 v1.0.5

### DIFF
--- a/plugins.v4.json
+++ b/plugins.v4.json
@@ -570,11 +570,11 @@
     {
       "id": "napcat-plugin-today-wife",
       "name": "今日老婆",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "description": "群聊互动插件 - 发送'今日老婆'随机抽取群成员作为今日老婆，支持每日记录和头像展示",
       "author": "Sakurakilove",
       "homepage": "https://github.com/Sakurakilove/napcat-plugin-today-wife",
-      "downloadUrl": "https://github.com/Sakurakilove/napcat-plugin-today-wife/releases/download/v1.0.3/napcat-plugin-today-wife.zip",
+      "downloadUrl": "https://github.com/Sakurakilove/napcat-plugin-today-wife/releases/download/v1.0.5/napcat-plugin-today-wife.zip",
       "tags": [
         "娱乐",
         "群聊"


### PR DESCRIPTION
## 🤖 自动更新插件索引

| 字段 | 值 |
|------|-----|
| **插件 ID** | `napcat-plugin-today-wife` |
| **插件名称** | 今日老婆 |
| **版本** | v1.0.5 |
| **作者** | Sakurakilove |
| **下载链接** | https://github.com/Sakurakilove/napcat-plugin-today-wife/releases/download/v1.0.5/napcat-plugin-today-wife.zip |
| **主页** | https://github.com/Sakurakilove/napcat-plugin-today-wife |
| **最低版本** | 4.14.0 |

---

> 此 PR 由 CI 自动创建，来源: [Sakurakilove/napcat-plugin-today-wife](https://github.com/Sakurakilove/napcat-plugin-today-wife) Release v1.0.5