### PR TITLE
🔌 [Mirai API HTTP] 更新至 v0.1.0

### DIFF
--- a/plugins.v4.json
+++ b/plugins.v4.json
@@ -55,6 +55,20 @@
         "工具"
       ],
       "minVersion": "4.14.13"
+    },
+    {
+      "id": "napcat-plugin-mirai-api-http",
+      "name": "Mirai API HTTP",
+      "version": "0.1.0",
+      "description": "NapCat 插件：实现 mirai-api-http 协议兼容层，支持 Ariadne 等客户端连接",
+      "author": "linnian",
+      "homepage": "https://github.com/Sibuxiangx/napcat-plugin-mirai-api-http",
+      "downloadUrl": "https://github.com/Sibuxiangx/napcat-plugin-mirai-api-http/releases/download/v0.1.0/napcat-plugin-mirai-api-http.zip",
+      "tags": [
+        "协议",
+        "工具"
+      ],
+      "minVersion": "4.14.0"
     }
   ]
 }


### PR DESCRIPTION
## 🤖 自动更新插件索引

| 字段 | 值 |
|------|-----|
| **插件 ID** | `napcat-plugin-mirai-api-http` |
| **插件名称** | Mirai API HTTP |
| **版本** | v0.1.0 |
| **作者** | linnian |
| **下载链接** | https://github.com/Sibuxiangx/napcat-plugin-mirai-api-http/releases/download/v0.1.0/napcat-plugin-mirai-api-http.zip |
| **主页** | https://github.com/Sibuxiangx/napcat-plugin-mirai-api-http |
| **最低版本** | 4.14.0 |

---

> 此 PR 由 CI 自动创建，来源: [Sibuxiangx/napcat-plugin-mirai-api-http](https://github.com/Sibuxiangx/napcat-plugin-mirai-api-http) Release v0.1.0