### PR TITLE
🔌 [掉线通知插件] 更新至 v1.0.0

### DIFF
--- a/plugins.v4.json
+++ b/plugins.v4.json
@@ -55,6 +55,20 @@
         "工具"
       ],
       "minVersion": "4.14.13"
+    },
+    {
+      "id": "napcat-plugin-offline-notification",
+      "name": "掉线通知插件",
+      "version": "1.0.0",
+      "description": "NapCatQQ 掉线通知插件，当机器人掉线时自动通过 Server 酱发送微信通知",
+      "author": "Forever灬笨",
+      "homepage": "https://github.com/KeepStupidForever/napcat-plugin-offline-notification",
+      "downloadUrl": "https://github.com/KeepStupidForever/napcat-plugin-offline-notification/releases/download/v1.0.0/napcat-plugin-offline-notification.zip",
+      "tags": [
+        "工具",
+        "通知"
+      ],
+      "minVersion": "4.14.0"
     }
   ]
 }


### PR DESCRIPTION
## 🤖 自动更新插件索引

| 字段 | 值 |
|------|-----|
| **插件 ID** | `napcat-plugin-offline-notification` |
| **插件名称** | 掉线通知插件 |
| **版本** | v1.0.0 |
| **作者** | Forever灬笨 |
| **下载链接** | https://github.com/KeepStupidForever/napcat-plugin-offline-notification/releases/download/v1.0.0/napcat-plugin-offline-notification.zip |
| **主页** | https://github.com/KeepStupidForever/napcat-plugin-offline-notification |
| **最低版本** | 4.14.0 |

---

> 此 PR 由 CI 自动创建，来源: [KeepStupidForever/napcat-plugin-offline-notification](https://github.com/KeepStupidForever/napcat-plugin-offline-notification) Release v1.0.0