### PR TITLE
[新增插件] napcat-plugin-qce（QQ 聊天记录导出 v5.5.57）

### DIFF
--- a/plugins.v4.json
+++ b/plugins.v4.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updateTime": "2026-02-21T15:58:54Z",
+  "updateTime": "2026-05-03T18:50:00Z",
   "plugins": [
     {
       "id": "napcat-plugin-builtin",
@@ -55,6 +55,19 @@
         "工具"
       ],
       "minVersion": "4.14.13"
+    },
+    {
+      "id": "napcat-plugin-qce",
+      "name": "QQ 聊天记录导出",
+      "version": "5.5.57",
+      "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
+      "author": "shuakami",
+      "homepage": "https://github.com/shuakami/qq-chat-exporter",
+      "downloadUrl": "https://github.com/shuakami/qq-chat-exporter/releases/download/v5.5.57/NapCat-Framework-QCE-v5.5.57.zip",
+      "tags": [
+        "工具"
+      ],
+      "minVersion": "4.14.0"
     }
   ]
 }


### PR DESCRIPTION
提交 QQ 聊天记录导出工具至插件索引（草稿，待维护者审阅打包形态后再转正式 PR）。

| 字段 | 值 |
|------|-----|
| 插件 ID | `napcat-plugin-qce` |
| 插件名称 | QQ 聊天记录导出 |
| 版本 | v5.5.57 |
| 作者 | shuakami |
| 主页 | https://github.com/shuakami/qq-chat-exporter |
| 下载链接 | https://github.com/shuakami/qq-chat-exporter/releases/download/v5.5.57/NapCat-Framework-QCE-v5.5.57.zip |
| 标签 | 工具 |
| 最低 NapCat 版本 | 4.14.0 |

## 插件简介

将 QQ 聊天记录导出为 HTML / JSON / TXT / Excel，支持：

- 时间范围筛选、按发送人筛选
- 批量任务、定时任务、断线续传
- 表情、图片、语音（SILK→MP3）、视频、文件资源处理
- 合并转发消息展开
- 自包含 HTML 导出（资源 base64 内联，单文件可分享）
- 多种文件命名格式与浏览器画廊视图

## 关于打包形态

当前 release 产物（`NapCat-Framework-QCE-v5.5.57.zip` / `NapCat-QCE-Windows-x64-...zip` / `NapCat-QCE-Linux-x64-...tar.gz`）是包含 NapCat Framework 的整体分发包，并不是 `napcat-plugin-template` 规范下的纯插件 zip（即根目录 `package.json` 的 `name` 以 `napcat-plugin-` 开头的那种）。

如果索引仓库的校验流程要求纯插件 zip，下一步会在 `shuakami/qq-chat-exporter` 增加一份独立的 `napcat-plugin-qce.zip` 构建产物（仅 `plugins/qq-chat-exporter` 目录 + 改名后的 `package.json`），并把 `downloadUrl` 切到那个产物上，再把本 PR 转成正式 PR。

先以草稿形式提交，等维护者确认打包要求后再继续。
