### PR TITLE
[QQ 聊天记录导出] 更新至 v5.5.60

### DIFF
--- a/plugins.v4.json
+++ b/plugins.v4.json
@@ -55,6 +55,19 @@
         "工具"
       ],
       "minVersion": "4.14.13"
+    },
+    {
+      "id": "napcat-plugin-qce",
+      "name": "QQ 聊天记录导出",
+      "version": "5.5.60",
+      "description": "导出 QQ 聊天记录为 HTML / JSON / TXT / Excel，支持时间筛选、批量任务、定时任务、表情图片语音视频资源处理、合并转发展开等。",
+      "author": "shuakami",
+      "homepage": "https://github.com/shuakami/qq-chat-exporter",
+      "downloadUrl": "https://github.com/shuakami/qq-chat-exporter/releases/download/v5.5.60/napcat-plugin-qce.zip",
+      "tags": [
+        "工具"
+      ],
+      "minVersion": "4.14.0"
     }
   ]
 }


### PR DESCRIPTION
## 自动更新插件索引

| 字段 | 值 |
|------|-----|
| **插件 ID** | `napcat-plugin-qce` |
| **插件名称** | QQ 聊天记录导出 |
| **版本** | v5.5.60 |
| **作者** | shuakami |
| **下载链接** | https://github.com/shuakami/qq-chat-exporter/releases/download/v5.5.60/napcat-plugin-qce.zip |
| **主页** | https://github.com/shuakami/qq-chat-exporter |
| **最低 NapCat 版本** | 4.14.0 |

---

> 此 PR 由 CI 自动创建，来源仓库 [shuakami/qq-chat-exporter](https://github.com/shuakami/qq-chat-exporter) Release v5.5.60